### PR TITLE
feat(Course Scheduling): Adding Lecture and Room DocTypes

### DIFF
--- a/academia/academia/doctype/lecture/lecture.json
+++ b/academia/academia/doctype/lecture/lecture.json
@@ -7,18 +7,184 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title"
+  "published",
+  "section_break_eezf",
+  "student_group",
+  "faculty_member",
+  "lecture_type",
+  "faculty_department",
+  "column_break_hlmi",
+  "status",
+  "university",
+  "faculty",
+  "course",
+  "academic_program",
+  "schedule_tab",
+  "academic_year",
+  "academic_term",
+  "academic_week",
+  "color",
+  "room",
+  "column_break_waqs",
+  "date",
+  "from_time",
+  "to_time",
+  "duration",
+  "content_tab",
+  "lms_tab",
+  "video",
+  "description"
  ],
  "fields": [
   {
-   "fieldname": "title",
+   "fieldname": "student_group",
+   "fieldtype": "Link",
+   "label": "Student Group",
+   "options": "Student Group"
+  },
+  {
+   "fieldname": "faculty_member",
+   "fieldtype": "Link",
+   "label": "Faculty Member ",
+   "options": "Faculty Member"
+  },
+  {
+   "fieldname": "lecture_type",
+   "fieldtype": "Select",
+   "label": "Lecture Type",
+   "options": "\nTheoretical\nPractical"
+  },
+  {
+   "fieldname": "faculty_department",
+   "fieldtype": "Link",
+   "label": "Faculty Department",
+   "options": "Faculty Department"
+  },
+  {
+   "fieldname": "column_break_hlmi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "university",
+   "fieldtype": "Link",
+   "label": "University",
+   "options": "University"
+  },
+  {
+   "fieldname": "faculty",
+   "fieldtype": "Link",
+   "label": "Faculty",
+   "options": "Faculty"
+  },
+  {
+   "fieldname": "course",
+   "fieldtype": "Link",
+   "label": "Course",
+   "options": "Course"
+  },
+  {
+   "fieldname": "academic_program",
+   "fieldtype": "Link",
+   "label": "Academic Program",
+   "options": "Academic Program"
+  },
+  {
+   "fieldname": "schedule_tab",
+   "fieldtype": "Tab Break",
+   "label": "Schedule"
+  },
+  {
+   "fieldname": "academic_year",
+   "fieldtype": "Link",
+   "label": "Academic Year",
+   "options": "Academic Year"
+  },
+  {
+   "fieldname": "academic_term",
    "fieldtype": "Data",
-   "label": "Title"
+   "label": "Academic Term"
+  },
+  {
+   "fieldname": "academic_week",
+   "fieldtype": "Data",
+   "label": "Academic Week"
+  },
+  {
+   "fieldname": "column_break_waqs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
+  },
+  {
+   "fieldname": "from_time",
+   "fieldtype": "Time",
+   "label": "From Time"
+  },
+  {
+   "fieldname": "to_time",
+   "fieldtype": "Time",
+   "label": "To Time"
+  },
+  {
+   "fieldname": "duration",
+   "fieldtype": "Duration",
+   "hide_days": 1,
+   "label": "Duration"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nCompleted\nScheduled\nOverdue\nUnscheduled"
+  },
+  {
+   "fieldname": "color",
+   "fieldtype": "Color",
+   "label": "Color"
+  },
+  {
+   "fieldname": "content_tab",
+   "fieldtype": "Tab Break",
+   "label": "Content"
+  },
+  {
+   "default": "0",
+   "fieldname": "published",
+   "fieldtype": "Check",
+   "label": "Published"
+  },
+  {
+   "fieldname": "section_break_eezf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "room",
+   "fieldtype": "Link",
+   "label": "Room",
+   "options": "Room"
+  },
+  {
+   "fieldname": "lms_tab",
+   "fieldtype": "Tab Break",
+   "label": "LMS"
+  },
+  {
+   "fieldname": "video",
+   "fieldtype": "Attach",
+   "label": "Video"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-12-17 08:00:09.756050",
+ "modified": "2024-01-29 04:59:02.848369",
  "modified_by": "Administrator",
  "module": "Academia",
  "name": "Lecture",

--- a/academia/academia/doctype/room/room.js
+++ b/academia/academia/doctype/room/room.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, SanU and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Room", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/academia/academia/doctype/room/room.json
+++ b/academia/academia/doctype/room/room.json
@@ -1,0 +1,59 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:room_name",
+ "creation": "2024-01-29 04:48:39.423641",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "room_name",
+  "room_number",
+  "seating_capacity"
+ ],
+ "fields": [
+  {
+   "fieldname": "room_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Room Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "room_number",
+   "fieldtype": "Data",
+   "label": "Room Number"
+  },
+  {
+   "fieldname": "seating_capacity",
+   "fieldtype": "Data",
+   "label": "Seating Capacity"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-01-29 04:56:33.272336",
+ "modified_by": "Administrator",
+ "module": "Academia",
+ "name": "Room",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/academia/academia/doctype/room/room.py
+++ b/academia/academia/doctype/room/room.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, SanU and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Room(Document):
+	pass

--- a/academia/academia/doctype/room/test_room.py
+++ b/academia/academia/doctype/room/test_room.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, SanU and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestRoom(FrappeTestCase):
+	pass


### PR DESCRIPTION
This pull request adds the main fields for "Room and Lecture " doctypes in the Academia application

- Adds  lecture  Fields "faculty Member, faculty, university, faculty Department, course, Academic Program and fields related with date and time "  for "lecture" Doctype in the Academia application
- add Room Fields "Room Name, Room Number, Seating Capacity " for "Room "Doctype

**Changes Made:**
Created a new doctypes in academia module :
**"Lecture:"** A Doctype Through we can create and scheduling lecture 
**"Room:"**A Doctype we can create a Room With capacity of seat

**Reviewers: @BakrAldubai ** 
 