### PR TITLE
Feat(core): Add some remaining permission Doctypes for the Academic User

### DIFF
--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5998,5 +5998,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:38:27.162833",
+  "name": "ece0f181f2",
+  "parent": "Level And Semester Enrollment",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5902,5 +5902,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:31:52.485967",
+  "name": "dea4140f8a",
+  "parent": "Faculty",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6238,5 +6238,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:55:20.925872",
+  "name": "6116ee99a8",
+  "parent": "Semester",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6334,5 +6334,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:02:22.997741",
+  "name": "3ab97e6fb7",
+  "parent": "Scientific Degree",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6310,5 +6310,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:00:40.135079",
+  "name": "70b840372d",
+  "parent": "Nationality",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6118,5 +6118,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:47:00.563419",
+  "name": "68006517bc",
+  "parent": "Building",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6094,5 +6094,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:45:39.501593",
+  "name": "efd0c0e479",
+  "parent": "Lab Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5758,5 +5758,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:21:18.496788",
+  "name": "ca1f433b91",
+  "parent": "Course Specification",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6430,5 +6430,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:08:41.627683",
+  "name": "009097229c",
+  "parent": "Study Method",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5542,5 +5542,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 1,
+  "cancel": 1,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 00:55:27.162877",
+  "name": "a9ee9ef10b",
+  "parent": "Asset Access Request",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 1,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6406,5 +6406,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:06:51.164962",
+  "name": "92f8a09351",
+  "parent": "Program Degree",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6358,5 +6358,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:03:37.797766",
+  "name": "22fd794834",
+  "parent": "Authority",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5470,5 +5470,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 00:33:26.370343",
+  "name": "f37d91eed1",
+  "parent": "Academic Attendance Tool",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5830,5 +5830,29 @@
   "share": 1,
   "submit": 1,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:26:49.590633",
+  "name": "10139d8c06",
+  "parent": "Evaluation Criteria Template",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5686,5 +5686,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:16:27.924067",
+  "name": "bc1097eb38",
+  "parent": "University",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5926,5 +5926,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:33:26.550513",
+  "name": "ae11d13d36",
+  "parent": "Faculty Member",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5566,5 +5566,29 @@
   "share": 1,
   "submit": 1,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 00:57:36.151348",
+  "name": "387153451f",
+  "parent": "Course Study Tool",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5878,5 +5878,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:29:35.796697",
+  "name": "cf7c833349",
+  "parent": "Academic Publication Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6454,5 +6454,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:10:02.201297",
+  "name": "ab36defa5b",
+  "parent": "Academic Specialty",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6286,5 +6286,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:58:59.742447",
+  "name": "081c862157",
+  "parent": "Consultation Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5446,5 +5446,29 @@
   "share": 0,
   "submit": 0,
   "write": 0
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-21 07:23:34.512306",
+  "name": "bccd06c4f6",
+  "parent": "Semester Enrollment",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5854,5 +5854,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:28:24.487334",
+  "name": "1f1379fb9a",
+  "parent": "Academic Services",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5590,5 +5590,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:01:42.389750",
+  "name": "033d9bc018",
+  "parent": "Journal Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5782,5 +5782,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:23:10.196457",
+  "name": "2ab6bd434c",
+  "parent": "Evaluation Criterion",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6190,5 +6190,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:52:29.403559",
+  "name": "8496161bdc",
+  "parent": "Student State",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5518,5 +5518,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 00:50:36.443039",
+  "name": "b370f3b760",
+  "parent": "Quiz Attempt",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5950,5 +5950,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 1,
+  "cancel": 1,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:34:52.090847",
+  "name": "02c062171e",
+  "parent": "Tenure Evaluation Request",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 1,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6142,5 +6142,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:48:41.691510",
+  "name": "08e8a77c50",
+  "parent": "Academic Publication",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5494,5 +5494,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 00:36:08.395584",
+  "name": "64b23e3fb3",
+  "parent": "LMS Assignment",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5662,5 +5662,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:14:04.429651",
+  "name": "eda0c14b6d",
+  "parent": "Course Enrollment Tool",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6262,5 +6262,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:57:29.722531",
+  "name": "ddf06efcd8",
+  "parent": "Lecture",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6022,5 +6022,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:40:00.431156",
+  "name": "c81163c661",
+  "parent": "Hour Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5710,5 +5710,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:18:00.347072",
+  "name": "328e427e0c",
+  "parent": "Schedule Template Version",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6214,5 +6214,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:54:02.677880",
+  "name": "3046418438",
+  "parent": "Level",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6478,5 +6478,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:12:10.648581",
+  "name": "a141bb6e27",
+  "parent": "Lesson Template",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6382,5 +6382,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:05:19.913795",
+  "name": "859abec6fe",
+  "parent": "Appreciation Type",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5806,5 +5806,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 1,
+  "cancel": 1,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:24:51.296003",
+  "name": "0b933d3531",
+  "parent": "Tenure Request",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 1,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6166,5 +6166,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:50:03.655562",
+  "name": "b8f0e1a73a",
+  "parent": "Academic Rank",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6070,5 +6070,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:43:22.268913",
+  "name": "02ea69dfdd",
+  "parent": "lab",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5614,5 +5614,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:03:48.976714",
+  "name": "f438c8fc78",
+  "parent": "Journal",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6502,5 +6502,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 02:13:22.129841",
+  "name": "dfb692f9a4",
+  "parent": "Lesson",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5974,5 +5974,29 @@
   "share": 1,
   "submit": 1,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:37:00.321441",
+  "name": "056e67d072",
+  "parent": "Program Specification",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5638,5 +5638,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:12:11.234312",
+  "name": "558d4f987d",
+  "parent": "Course Study",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -5734,5 +5734,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:19:37.613054",
+  "name": "bdedcca601",
+  "parent": "Facility",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]

--- a/academia/fixtures/custom_docperm.json
+++ b/academia/fixtures/custom_docperm.json
@@ -6046,5 +6046,29 @@
   "share": 1,
   "submit": 0,
   "write": 1
+ },
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 0,
+  "import": 0,
+  "modified": "2024-07-24 01:42:05.099471",
+  "name": "cfd4cbbf0f",
+  "parent": "Faculty Department",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Academic User",
+  "select": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
  }
 ]


### PR DESCRIPTION
We add some Doctypes permissions for Academic User

there is the remaining Doctypes that we added:

- Semester Enrollmen
- Attendance Tool
- LMS Assignment
- Quiz Attempt
- Asset Access Request
- Course Study Tool
- Journal Type
- Journal
- Course Study
- Course Enrollment Tool
- University
- Schedule Template Version
- Facility
- Course Specification
- Evaluation Criterion
- Tenure Request
- Evaluation Criteria Template
- Academic Services
- Academic Publication Type
- Faculty
- Faculty Member
- Tenure Evaluation Request
- Program Specification
- Level And Semester Enrollment
- Hour Type
- Faculty Department
- lab
- Lab Type
- Building
- Academic Publication
- Academic Rank
- Student State
- Level
- Semester
- Lecture
- Consultation Type
- Nationality
- Scientific Degree
- Authority
- Appreciation Type
- Program Degree
- Study Method
- Academic Specialty
- Lesson Template
- Lesson
 
